### PR TITLE
Make command instantiation overrideable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - hhvm
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.2.0/setup' -O - | php
+  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.3.0/setup' -O - | php
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini

--- a/class.pth
+++ b/class.pth
@@ -1,3 +1,3 @@
-src/main/php/
+!src/main/php/
 src/test/php/
 src/test/resources/

--- a/src/main/php/xp/command/CmdRunner.class.php
+++ b/src/main/php/xp/command/CmdRunner.class.php
@@ -282,7 +282,11 @@ class CmdRunner {
       $context->setParams($params->string);
     }
 
-    $instance= $class->newInstance();
+    if ($class->hasMethod('newInstance')) {
+      $instance= $class->getMethod('newInstance')->invoke(null, []);
+    } else {
+      $instance= $class->newInstance();
+    }
     $instance->in= self::$in;
     $instance->out= self::$out;
     $instance->err= self::$err;

--- a/src/main/php/xp/command/Runner.class.php
+++ b/src/main/php/xp/command/Runner.class.php
@@ -300,7 +300,11 @@ class Runner {
       $context->setParams($params->string);
     }
 
-    $instance= $class->newInstance();
+    if ($class->hasMethod('newInstance')) {
+      $instance= $class->getMethod('newInstance')->invoke(null, []);
+    } else {
+      $instance= $class->newInstance();
+    }
     $instance->in= self::$in;
     $instance->out= self::$out;
     $instance->err= self::$err;

--- a/src/test/php/util/cmd/unittest/RunnerTest.class.php
+++ b/src/test/php/util/cmd/unittest/RunnerTest.class.php
@@ -737,4 +737,23 @@ key=overwritten_value'
     $this->assertEquals('', $this->err->getBytes());
     $this->assertEquals('Have overwritten_value', $this->out->getBytes());
   }
+
+  #[@test]
+  public function class_with_create() {
+    $command= newinstance(Command::class, [], '{
+      private $created= "constructor";
+
+      public static function newInstance() {
+        $self= new self();
+        $self->created= "user-supplied creation method";
+        return $self;
+      }
+
+      public function run() {
+        $this->out->write("Created via ", $this->created);
+      }
+    }');
+    $this->runWith([nameof($command)]);
+    $this->assertEquals('Created via user-supplied creation method', $this->out->getBytes());
+  }
 }

--- a/src/test/php/util/cmd/unittest/RunnerTest.class.php
+++ b/src/test/php/util/cmd/unittest/RunnerTest.class.php
@@ -733,7 +733,7 @@ key=overwritten_value'
         // Not reached
       }
     }');
-    $this->runWith(['-c', 'res://net/xp_framework/unittest/util/cmd/add_etc', '-c', 'res://net/xp_framework/unittest/util/cmd/', nameof($command)]);
+    $this->runWith(['-c', 'res://util/cmd/unittest/add_etc', '-c', 'res://util/cmd/unittest/', nameof($command)]);
     $this->assertEquals('', $this->err->getBytes());
     $this->assertEquals('Have overwritten_value', $this->out->getBytes());
   }

--- a/src/test/resources/util/cmd/unittest/add_etc/debug.ini
+++ b/src/test/resources/util/cmd/unittest/add_etc/debug.ini
@@ -1,0 +1,2 @@
+[section]
+key=overwritten_value


### PR DESCRIPTION
Done by defining a static `newInstance()` method which returns an instance of the Command class.

This can be useful when using an injection framework like [xp-forge/inject](https://github.com/xp-forge/inject). The newInstance() method is the place to do the wiring in!
