### PR TITLE
Pass configuration to command constructor

### DIFF
--- a/src/main/php/util/cmd/Config.class.php
+++ b/src/main/php/util/cmd/Config.class.php
@@ -1,0 +1,77 @@
+<?php namespace util\cmd;
+
+use util\FilesystemPropertySource;
+use util\ResourcePropertySource;
+use util\CompositeProperties;
+use util\Objects;
+use lang\ElementNotFoundException;
+
+/**
+ * The command line for any command allows specifiy explicit ("-c [source]")
+ * config sources; implicitely searching either `./etc` or `.` for property
+ * files. The `properties()` method then searches these locations.
+ *
+ * @test  xp://util.cmd.unittest.ConfigTest
+ */
+class Config {
+  private $sources= [];
+
+  /**
+   * Creates a new config instance from given sources
+   *
+   * @param  string... $source
+   */
+  public function __construct() {
+    foreach (func_get_args() as $source) {
+      $this->append($source);
+    }
+  }
+
+  /**
+   * Appends property source
+   *
+   * @param  string $source
+   * @return void
+   */
+  public function append($source) {
+    if (is_dir($source)) {
+      $this->sources[]= new FilesystemPropertySource($source);
+    } else if (0 === strncmp('res://', $source, 6)) {
+      $this->sources[]= new ResourcePropertySource(substr($source, 6));
+    } else {
+      $this->sources[]= new ResourcePropertySource($source);
+    }
+  }
+
+  /** @retun bool */
+  public function isEmpty() { return empty($this->sources); }
+
+  /** @return util.PropertySource[] */
+  public function sources() { return $this->sources; }
+
+  /**
+   * Gets properties
+   *
+   * @param  string $name
+   * @return util.PropertyAccess
+   * @throws lang.ElementNotFoundException
+   */
+  public function properties($name) {
+    $found= [];
+    foreach ($this->sources as $source) {
+      if ($source->provides($name)) {
+        $found[]= $source->fetch($name);
+      }
+    }
+
+    switch (sizeof($found)) {
+      case 0: throw new ElementNotFoundException(sprintf(
+        'Cannot find properties "%s" in any of %s',
+        $name,
+        Objects::stringOf($this->sources)
+      ));
+      case 1: return $found[0];
+      default: return new CompositeProperties($found);
+    }
+  }
+}

--- a/src/test/php/util/cmd/unittest/ConfigTest.class.php
+++ b/src/test/php/util/cmd/unittest/ConfigTest.class.php
@@ -1,0 +1,78 @@
+<?php namespace util\cmd\unittest;
+ 
+use util\cmd\Config;
+use util\FilesystemPropertySource;
+use util\ResourcePropertySource;
+use util\PropertyAccess;
+use lang\ElementNotFoundException;
+
+class ConfigTest extends \unittest\TestCase {
+  
+  #[@test]
+  public function can_create() {
+    new Config();
+  }
+
+  #[@test]
+  public function initially_empty() {
+    $this->assertTrue((new Config())->isEmpty());
+  }
+
+  #[@test]
+  public function not_empty_if_created_with_source() {
+    $this->assertFalse((new Config('.'))->isEmpty());
+  }
+
+  #[@test]
+  public function not_empty_if_created_with_sources() {
+    $this->assertFalse((new Config('.', 'util/cmd/unittest'))->isEmpty());
+  }
+
+  #[@test]
+  public function no_longer_empty_after_appending_source() {
+    $config= new Config();
+    $config->append('.');
+    $this->assertFalse($config->isEmpty());
+  }
+
+  #[@test]
+  public function append_dir() {
+    $config= new Config();
+    $config->append('.');
+    $this->assertEquals([new FilesystemPropertySource('.')], $config->sources());
+  }
+
+  #[@test]
+  public function append_resource() {
+    $config= new Config();
+    $config->append('live');
+    $this->assertEquals([new ResourcePropertySource('live')], $config->sources());
+  }
+
+  #[@test]
+  public function append_resource_with_explicit_res_prefix() {
+    $config= new Config();
+    $config->append('res://live');
+    $this->assertEquals([new ResourcePropertySource('live')], $config->sources());
+  }
+
+  #[@test, @expect(ElementNotFoundException::class)]
+  public function properties_raises_exception_when_nothing_found() {
+    (new Config())->properties('test');
+  }
+
+  #[@test]
+  public function properties() {
+    $config= new Config();
+    $config->append('util/cmd/unittest');
+    $this->assertEquals('value', $config->properties('debug')->readString('section', 'key'));
+  }
+
+  #[@test]
+  public function composite_properties() {
+    $config= new Config();
+    $config->append('util/cmd/unittest/add_etc');
+    $config->append('util/cmd/unittest');
+    $this->assertEquals('overwritten_value', $config->properties('debug')->readString('section', 'key'));
+  }
+}


### PR DESCRIPTION
This way, code working with explicit "-c [source]" or implicit configuration (inside etc/ or the current directory) can be moved there. This can be used to set up an injector with bindings configured in a properties file.
## Example

_(Uses the [xp-forge/inject](https://github.com/xp-forge/inject) library)_

test.ini:

``` ini
webservices.rest.RestClient=webservices.rest.RestClient('https://github.com/api/v3')
```

Test.class.php:

``` php
<?php

use inject\Injector;
use inject\ConfiguredBindings;
use webservices\rest\RestClient;

class Test extends \util\cmd\Command {
  private $api;

  #[@inject]
  public function __construct(RestClient $api) {
    $this->api= $api;
  }

  public static function newInstance($config) {
    $inject= new Injector(new ConfiguredBindings($config->properties('test')));
    return $inject->get(self::class);
  }

  public function run() {
    $this->out->write($this->api);
    // ...
  }
}
```
## Future outlook

This can be seen as the first step towards deprecating the builtin method injection mechanism based on the `PropertyManager`, `Logger` and `ConnectionManager` singletons. In a future major version, both could be removed.

If the inject library was made part of this, the `newInstance()` method could be made available either in the base class or as a trait:

``` php
<?php namespace util\cmd;

trait InjectConfig {

  /** @return inject.Binding[] */
  private static function bindings() { return []; }

  /** @return string */
  private static function config() { return null; }

  public static function newInstance($config) {
    $type= typeof($this);
    $name= strtolower($type->getSimpleName());
    $inject= new Injector();
    foreach (self::bindings() as $binding) {
      $inject->add($binding);
    }
    $inject->add(new ConfiguredBindings($config->properties($name), self::config()));
    return $inject->get($type);
  }
}
```

/cc @mikey179
