### PR TITLE
Add support for named commands

### DIFF
--- a/src/main/php/util/cmd/Commands.class.php
+++ b/src/main/php/util/cmd/Commands.class.php
@@ -3,6 +3,10 @@
 use lang\ClassLoader;
 use lang\IllegalArgumentException;
 
+/**
+ * Commands factory. Loads classes, files and named commands by using
+ * a package-based search.
+ */
 final class Commands {
   private static $packages= [];
 
@@ -24,7 +28,7 @@ final class Commands {
   /**
    * Loads a named command
    *
-   * @param  lang.CLassLoader $cl
+   * @param  lang.ClassLoader $cl
    * @param  string $name
    * @return lang.XPClass
    * @throws lang.IllegalArgumentException if no class can be found by the given name

--- a/src/main/php/util/cmd/Commands.class.php
+++ b/src/main/php/util/cmd/Commands.class.php
@@ -1,0 +1,49 @@
+<?php namespace util\cmd;
+
+use lang\XPClass;
+use lang\ClassLoader;
+use lang\IllegalArgumentException;
+
+final class Commands {
+  private static $named= [];
+
+  /**
+   * Prevent instantiation
+   */
+  private function __construct() { }
+
+  /**
+   * Register named commands
+   *
+   * @param  [:string] $named Map of names => classes
+   * @return void
+   */
+  public static function register(array $named) {
+    self::$named= array_merge(self::$named, $named);
+  }
+
+  /**
+   * Find a command by a given name
+   *
+   * @param  string $name
+   * @return lang.XPClass
+   * @throws lang.ClassNotFoundException
+   * @throws lang.IllegalArgumentException if class is not runnable
+   */
+  public static function named($name) {
+    if (isset(self::$named[$name])) {
+      $class= XPClass::forName(self::$named[$name]);
+    } else if (is_file($name)) {
+      $class= ClassLoader::getDefault()->loadUri($name);
+    } else {
+      $class= XPClass::forName($name);
+    }
+
+    // Check whether class is runnable
+    if (!$class->isSubclassOf('lang.Runnable')) {
+      throw new IllegalArgumentException($class->getName().' is not runnable');
+    }
+
+    return $class;
+  }
+}

--- a/src/main/php/util/cmd/Commands.class.php
+++ b/src/main/php/util/cmd/Commands.class.php
@@ -2,6 +2,7 @@
 
 use lang\ClassLoader;
 use lang\IllegalArgumentException;
+use lang\reflect\Package;
 
 /**
  * Commands factory. Loads classes, files and named commands by using
@@ -22,21 +23,29 @@ final class Commands {
    * @return void
    */
   public static function registerPackage($package) {
-    self::$packages[]= $package;
+    self::$packages[]= Package::forName($package);
+  }
+
+  /**
+   * Gets all registered packages
+   *
+   * @return lang.reflect.Package[]
+   */
+  public static function allPackages() {
+    return self::$packages;
   }
 
   /**
    * Loads a named command
    *
-   * @param  lang.ClassLoader $cl
    * @param  string $name
    * @return lang.XPClass
    * @throws lang.IllegalArgumentException if no class can be found by the given name
    */
-  private static function loadNamed($cl, $name) {
+  private static function loadNamed($name) {
     $class= implode('', array_map('ucfirst', explode('-', $name)));
     foreach (self::$packages as $package) {
-      if ($cl->providesClass($qualified= $package.'.'.$class)) return $cl->loadClass($qualified);
+      if ($package->providesClass($class)) return $package->loadClass($qualified);
     }
     throw new IllegalArgumentException('No command named "'.$name.'"');
   }
@@ -56,7 +65,7 @@ final class Commands {
     } else if (strstr($name, '.')) {
       $class= $cl->loadClass($name);
     } else {
-      $class= self::loadNamed($cl, $name);
+      $class= self::loadNamed($name);
     }
 
     // Check whether class is runnable

--- a/src/main/php/util/cmd/Commands.class.php
+++ b/src/main/php/util/cmd/Commands.class.php
@@ -1,6 +1,5 @@
 <?php namespace util\cmd;
 
-use lang\XPClass;
 use lang\ClassLoader;
 use lang\IllegalArgumentException;
 
@@ -23,7 +22,12 @@ final class Commands {
   }
 
   /**
-   * 
+   * Loads a named command
+   *
+   * @param  lang.CLassLoader $cl
+   * @param  string $name
+   * @return lang.XPClass
+   * @throws lang.IllegalArgumentException if no class can be found by the given name
    */
   private static function loadNamed($cl, $name) {
     $class= implode('', array_map('ucfirst', explode('-', $name)));

--- a/src/main/php/xp/command/AbstractRunner.class.php
+++ b/src/main/php/xp/command/AbstractRunner.class.php
@@ -111,16 +111,14 @@ abstract class AbstractRunner {
   /**
    * Runs class
    *
-   * @param  string $name
+   * @param  string $command
    * @param  util.cmd.ParamString $params
    * @param  util.cmd.Config $config
    * @return int
    */
-  protected function runClass($name, $params, $config) {
-
-    // Class file or class name
+  protected function runCommand($command, $params, $config) {
     try {
-      $class= Commands::named($name);
+      $class= Commands::named($command);
     } catch (Throwable $e) {
       self::$err->writeLine('*** ', $this->verbose ? $e : $e->getMessage());
       return 1;

--- a/src/main/php/xp/command/CmdRunner.class.php
+++ b/src/main/php/xp/command/CmdRunner.class.php
@@ -153,8 +153,7 @@ class CmdRunner extends AbstractRunner {
       $markdown.= "\n";
     }
 
-    $markdown.= "* In global package\n\n";
-    $markdown.= $commandsIn(Package::forName(null));
+    $markdown.= "* In global package\n\n".$commandsIn(Package::forName(null));
 
     Help::render(self::$err, $markdown, []);
   }

--- a/src/main/php/xp/command/CmdRunner.class.php
+++ b/src/main/php/xp/command/CmdRunner.class.php
@@ -169,8 +169,7 @@ class CmdRunner extends AbstractRunner {
     }
 
     unset($params->list[-1]);
-    $classname= $params->value($offset);
     $classparams= new ParamString(array_slice($params->list, $offset+ 1));
-    return $this->runClass($classname, $classparams, $config);
+    return $this->runCommand($params->value($offset), $classparams, $config);
   }
 }

--- a/src/main/php/xp/command/Runner.class.php
+++ b/src/main/php/xp/command/Runner.class.php
@@ -141,13 +141,13 @@ class Runner extends AbstractRunner {
    */
   protected function listCommands() {
     $commandsIn= function($package) {
-      $markdown= '';
+      $text= '';
       foreach ($package->getClasses() as $class) {
         if ($class->isSubclassOf('util.cmd.Command') && !Modifiers::isAbstract($class->getModifiers())) {
-          $markdown.= '  $ xpcli '.$class->getSimpleName()."\n";
+          $text.= '  $ xpcli '.$class->getSimpleName()."\n";
         }
       }
-      return $markdown ?: '  (no commands)';
+      return $text ?: '  (no commands)';
     };
 
     self::$err->writeLine('Named commands');

--- a/src/main/php/xp/command/Runner.class.php
+++ b/src/main/php/xp/command/Runner.class.php
@@ -179,8 +179,7 @@ class Runner extends AbstractRunner {
     }
 
     unset($params->list[-1]);
-    $classname= $params->value($offset);
     $classparams= new ParamString(array_slice($params->list, $offset+ 1));
-    return $this->runClass($classname, $classparams, $config);
+    return $this->runCommand($params->value($offset), $classparams, $config);
   }
 }

--- a/src/test/php/util/cmd/unittest/AbstractRunnerTest.class.php
+++ b/src/test/php/util/cmd/unittest/AbstractRunnerTest.class.php
@@ -87,18 +87,18 @@ abstract class AbstractRunnerTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function nonExistantFile() {
-    $return= $this->runWith(['@@NON-EXISTANT@@.'.\xp::CLASS_FILE_EXT]);
-    $this->assertEquals(1, $return);
-    $this->assertOnStream($this->err, '*** Cannot load class from non-existant file');
-    $this->assertEquals('', $this->out->getBytes());
-  }
-
-  #[@test]
   public function notRunnableClass() {
     $return= $this->runWith([nameof($this)]);
     $this->assertEquals(1, $return);
     $this->assertOnStream($this->err, '*** '.nameof($this).' is not runnable');
+    $this->assertEquals('', $this->out->getBytes());
+  }
+
+  #[@test]
+  public function notRunnableFile() {
+    $return= $this->runWith([__FILE__]);
+    $this->assertEquals(1, $return);
+    $this->assertOnStream($this->err, '*** '.strtr(self::class, '\\', '.').' is not runnable');
     $this->assertEquals('', $this->out->getBytes());
   }
 

--- a/src/test/php/util/cmd/unittest/AbstractRunnerTest.class.php
+++ b/src/test/php/util/cmd/unittest/AbstractRunnerTest.class.php
@@ -79,10 +79,10 @@ abstract class AbstractRunnerTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function nonExistantClass() {
+  public function nonExistant() {
     $return= $this->runWith(['@@NONEXISTANT@@']);
     $this->assertEquals(1, $return);
-    $this->assertOnStream($this->err, '*** Class "@@NONEXISTANT@@" could not be found');
+    $this->assertOnStream($this->err, '*** No command named "@@NONEXISTANT@@"');
     $this->assertEquals('', $this->out->getBytes());
   }
 


### PR DESCRIPTION
> The missing piece between  `xp migrate` and `com.example.cmd.Migrate` really only is the package name,  com.example.cmd

This pull request adds an API to add this missing piece via `module.xp`:

``` php
<?php namespace de\thekid\dialog;

use util\cmd\Commands;

module dialog {

  public function initialize() {
    Commands::registerPackage('de.thekid.dialog.cmd');
  }
}
```

...and a `-l` option to list named commands:

![list-commands](https://cloud.githubusercontent.com/assets/696742/14944576/509c914c-0ff7-11e6-90d2-4cd96b1bc1b0.png)
