### PR TITLE
Make commands runnable via `xp [class]`

### DIFF
--- a/src/main/php/util/cmd/Command.class.php
+++ b/src/main/php/util/cmd/Command.class.php
@@ -1,5 +1,7 @@
 <?php namespace util\cmd;
 
+use xp\command\CmdRunner;
+
 /**
  * Base class for all commands
  */
@@ -11,5 +13,15 @@ abstract class Command extends \lang\Object implements \lang\Runnable {
     $out = null,
     #[@type('io.streams.StringWriter')]
     $err = null;
-  
+
+  /**
+   * Make Commands runnable via `xp`.
+   *
+   * @param  string[] $args
+   * @return int
+   */
+  public static function main($args) {
+    array_unshift($args, strtr(get_called_class(), '\\', '.'));
+    return CmdRunner::main($args);
+  }
 }

--- a/src/test/php/util/cmd/unittest/AbstractRunnerTest.class.php
+++ b/src/test/php/util/cmd/unittest/AbstractRunnerTest.class.php
@@ -732,4 +732,15 @@ abstract class AbstractRunnerTest extends \unittest\TestCase {
     $this->runWith([nameof($command)]);
     $this->assertOnStream($this->out, 'Created with util.cmd.Config');
   }
+
+  #[@test]
+  public function can_be_invoked_via_main() {
+    $command= newinstance(Command::class, [], [
+      'arg' => 0,
+      '#[@arg] setArg' => function($arg) { $this->arg= $arg; },
+      'run' => function() { return $this->arg; }
+    ]);
+
+    $this->assertEquals(12, $command::main(['-a', 12]));
+  }
 }


### PR DESCRIPTION
Previous:

``` sh
$ xp Test
Uncaught exception: Exception lang.Error (Call to undefined static method lang.Object::main())
  at lang.Object::__callStatic((0x4)'main', array[1]) [line 369 of class-main.php]
```

Now:

``` sh
$ xp Test
Test

$ xp Test -?
@FileSystemCL<.>
Test
════════════════════════════════════════════════════════════════════════

> Usage

  $ xp cmd Test
```

Alternatively, we could output an error message like _The class `Test' is intended for use by the "cmd" subcommand_, but because it's so easily fixable, why not simply offer this?

@johannes85 & @kiesel - what do you think about this?
