### PR TITLE
Change from `set` to `use` prefix for argument methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,16 @@ class Query extends Command {
   private $connection, $query;
   private $verbose= false;
 
-  /**
-   * Connection DSN, e.g. `mysql://user:pass@host[:port][/database]`
-   *
-   * @param  string $dsn
-   */
+  /** Connection DSN, e.g. `mysql://user:pass@host[:port][/database]` */
   #[Arg(position: 0)]
-  public function setConnection($dsn) {
+  public function useConnection(string $dsn) {
     $this->connection= DriverManager::getConnection($dsn);
     $this->connection->connect();
   }
 
-  /**
-   * SQL query. Use `-` to read from standard input.
-   *
-   * @param  string $query
-   */
+  /** SQL query. Use `-` to read from standard input */
   #[Arg(position: 1)]
-  public function setQuery($query) {
+  public function useQuery(string $query) {
     if ('-' === $query) {
       $this->query= Streams::readAll($this->in->stream());
     } else {
@@ -50,11 +42,9 @@ class Query extends Command {
     }
   }
 
-  /**
-   * Verbose output
-   */
+  /** Verbose output */
   #[Arg]
-  public function setVerbose() {
+  public function useVerbose() {
     $this->verbose= true;
   }
 

--- a/src/main/php/xp/command/CmdRunner.class.php
+++ b/src/main/php/xp/command/CmdRunner.class.php
@@ -105,7 +105,7 @@ class CmdRunner {
     $extra= $details= $positional= [];
     foreach ($type->methods()->annotated(Arg::class) as $method) {
       $arg= $method->annotation(Arg::class)->arguments();
-      $name= strtolower(preg_replace('/^set/', '', $method->name()));
+      $name= strtolower(preg_replace('/^(use|set)/', '', $method->name()));
       $first= $method->parameter(0);
       $optional= $first ? $first->optional() : true;
       $comment= $method->comment();
@@ -253,7 +253,7 @@ class CmdRunner {
           $name= '#'.($position + 1);
           $short= null;
         } else {
-          $select= $name= $arg->argument('name') ?? strtolower(preg_replace('/^set/', '', $method->name()));
+          $select= $name= $arg->argument('name') ?? strtolower(preg_replace('/^(use|set)/', '', $method->name()));
           $short= $arg->argument('short');
         }
 

--- a/src/test/php/util/cmd/unittest/CmdRunnerTest.class.php
+++ b/src/test/php/util/cmd/unittest/CmdRunnerTest.class.php
@@ -569,4 +569,18 @@ class CmdRunnerTest {
 
     Assert::equals(12, $command::main(['-a', 12]));
   }
+
+  #[Test]
+  public function argument_name_with_use() {
+    $command= newinstance(Command::class, [], '{
+      private $arg= null;
+
+      #[Arg]
+      public function useArg($arg) { $this->arg= $arg; }
+      public function run() { $this->out->write($this->arg); }
+    }');
+
+    $this->runWith([nameof($command), '-a', 'UNITTEST']);
+    Assert::equals('UNITTEST', $this->out->bytes());
+  }
 }


### PR DESCRIPTION
Keeps support for `set` but prefers `use`. Example:

```php
use util\cmd\{Arg, Command};

class Test extends Command {
  private $name;

  #[Arg]
  public function useName($name= null) {
    $this->name= $name ?? getenv('USER');
  }

  public function run() {
    $this->out->writeLine('Hello ', $this->name);
  }
}
```